### PR TITLE
Update Microsoft.NETCore.App dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,7 @@ for (var index = 0; index < players.Length; index++)
 ## Building on .NET Core
 
 You can also build glicko2-csharp for .NET Core. To do this, run:
-```dotnet restore
-dotnet build -c Release```
+```
+dotnet restore
+dotnet build -c Release
+```

--- a/project.json
+++ b/project.json
@@ -7,7 +7,7 @@
         "netcoreapp1.0": {
             "dependencies": {
                 "Microsoft.NETCore.App": {
-                    "version": "1.0.0-rc2-3002702",
+                    "version": "1.0.0",
                     "type": "platform"
                 }
             }

--- a/project.json
+++ b/project.json
@@ -11,7 +11,9 @@
                     "type": "platform"
                 }
             }
-        }
+        },
+		"net45": {}
     },
-    authors: [ "MaartenStaa" ]
+    "runtimes": { "win": {}, "ubuntu.16.04-x64": {} },
+    "authors": [ "MaartenStaa" ]
 }

--- a/project.json
+++ b/project.json
@@ -12,5 +12,6 @@
                 }
             }
         }
-    }
+    },
+    authors: [ "MaartenStaa" ]
 }

--- a/project.json
+++ b/project.json
@@ -14,6 +14,6 @@
         },
         "net45": {}
     },
-    "runtimes": { "win": {}, "ubuntu.16.04-x64": {} },
+    "runtimes": { "any": {}, "win": {} },
     "authors": [ "MaartenStaa" ]
 }

--- a/project.json
+++ b/project.json
@@ -12,7 +12,7 @@
                 }
             }
         },
-		"net45": {}
+        "net45": {}
     },
     "runtimes": { "win": {}, "ubuntu.16.04-x64": {} },
     "authors": [ "MaartenStaa" ]


### PR DESCRIPTION
The 1.0.0-rc2 version is an older version. This commit fixes that.

[Update] It also fixes builds from Visual Studio. Those were broken because of project.json (I thought it would just ignore that file, but apparently it didn't). That's fixed.
